### PR TITLE
fix Missing imports with React 15.4.0

### DIFF
--- a/dev-env/package.json
+++ b/dev-env/package.json
@@ -45,7 +45,7 @@
     "react-redux": "^4.4.5",
     "react-router": "^2.4.1",
     "react-router-redux": "^4.0.4",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.0",
     "redux": "^3.5.2"
   }
 }


### PR DESCRIPTION
按照原先的package.json安装依赖，会安装react 15.2.0以上的版本，当前最新的react为15.4.0，其中移除了react/lib中的部门组件，将导致react-tap-event-plugin 1.0.0无法获得依赖
[详见](https://github.com/zilverline/react-tap-event-plugin/issues/85)